### PR TITLE
Fix incorrect spec

### DIFF
--- a/src/akiroz/re_frame/storage.cljs
+++ b/src/akiroz/re_frame/storage.cljs
@@ -68,7 +68,7 @@
 (s/def ::cofx keyword?)
 (s/fdef reg-co-fx!
   :args (s/cat :store-key keyword?
-               :handlers (s/keys :req [(or ::fx ::cofx)])))
+               :handlers (s/keys :req-un [(or ::fx ::cofx)])))
 
 
 (defn persist-db [store-key db-key]


### PR DESCRIPTION
This small PR fixes an incorrect spec definition: it required the :fx and :cofx keywords to be namespaced, while the actual code assumes un-namespaced keywords. This caused failures in code that instrumented functions.